### PR TITLE
NOZ-84: Remove GITHUB_OWNER and GITHUB_REPO

### DIFF
--- a/src/github.js
+++ b/src/github.js
@@ -173,14 +173,13 @@ async function checkoutBranch (branchName, repoPath) {
  * - BASE_BRANCH: The base branch for PRs (defaults to 'main')
  */
 async function createPR (issue, branchName, repoInfo) {
-  try {
-    if (!repoInfo?.owner || !repoInfo?.name) {
-      log('❌', 'Repository owner and name are required', 'red')
-      return null
-    }
+  if (!repoInfo?.owner || !repoInfo?.name) {
+    log('❌', 'Repository owner and name are required', 'red')
+    return null
+  }
 
-    const owner = repoInfo.owner
-    const repo = repoInfo.name
+  try {
+    const { owner, name: repo } = repoInfo
     const baseBranch = process.env.BASE_BRANCH || 'main'
     const repoPath = `./${repoInfo.name}`
 
@@ -265,14 +264,13 @@ ${issue.description}`
  * @returns {Promise<Object|null>} The existing PR object if found, null otherwise
  */
 async function findExistingPR (issue, repoInfo) {
-  try {
-    if (!repoInfo?.owner || !repoInfo?.name) {
-      log('❌', 'Repository owner and name are required', 'red')
-      return null
-    }
+  if (!repoInfo?.owner || !repoInfo?.name) {
+    log('❌', 'Repository owner and name are required', 'red')
+    return null
+  }
 
-    const owner = repoInfo.owner
-    const repo = repoInfo.name
+  try {
+    const { owner, name: repo } = repoInfo
 
     const { data: pulls } = await octokit.rest.pulls.list({
       owner,
@@ -314,14 +312,13 @@ async function findExistingPR (issue, repoInfo) {
 async function getPRComments (prNumber, repoInfo) {
   log('🔍', `Getting comments for PR #${prNumber}`, 'blue')
 
-  try {
-    if (!repoInfo?.owner || !repoInfo?.name) {
-      log('❌', 'Repository owner and name are required', 'red')
-      return null
-    }
+  if (!repoInfo?.owner || !repoInfo?.name) {
+    log('❌', 'Repository owner and name are required', 'red')
+    return null
+  }
 
-    const owner = repoInfo.owner
-    const repo = repoInfo.name
+  try {
+    const { owner, name: repo } = repoInfo
 
     // Get line-specific review comments
     const { data: reviewComments } = await octokit.rest.pulls.listReviewComments({
@@ -513,14 +510,13 @@ async function updateExistingPR (issue, repoInfo) {
 async function postReviewCommentReply (prNumber, inReplyToId, body, repoInfo) {
   log('💬', `Posting review comment reply to PR #${prNumber}`, 'blue')
 
-  try {
-    if (!repoInfo?.owner || !repoInfo?.name) {
-      log('❌', 'Repository owner and name are required', 'red')
-      return null
-    }
+  if (!repoInfo?.owner || !repoInfo?.name) {
+    log('❌', 'Repository owner and name are required', 'red')
+    return null
+  }
 
-    const owner = repoInfo.owner
-    const repo = repoInfo.name
+  try {
+    const { owner, name: repo } = repoInfo
 
     // Post the reply to the review comment
     const { data: comment } = await octokit.rest.pulls.createReplyForReviewComment({
@@ -564,14 +560,13 @@ async function postReviewCommentReply (prNumber, inReplyToId, body, repoInfo) {
 async function postPRComment (prNumber, body, repoInfo, quotedComment = null) {
   log('💬', `Posting comment to PR #${prNumber}`, 'blue')
 
-  try {
-    if (!repoInfo?.owner || !repoInfo?.name) {
-      log('❌', 'Repository owner and name are required', 'red')
-      return null
-    }
+  if (!repoInfo?.owner || !repoInfo?.name) {
+    log('❌', 'Repository owner and name are required', 'red')
+    return null
+  }
 
-    const owner = repoInfo.owner
-    const repo = repoInfo.name
+  try {
+    const { owner, name: repo } = repoInfo
 
     let finalBody = body
 
@@ -624,14 +619,13 @@ async function postPRComment (prNumber, body, repoInfo, quotedComment = null) {
 async function addCommentReaction (commentId, commentType, reaction, repoInfo) {
   log('👁️', `Adding ${reaction} reaction to ${commentType} comment ${commentId}`, 'blue')
 
-  try {
-    if (!repoInfo?.owner || !repoInfo?.name) {
-      log('❌', 'Repository owner and name are required', 'red')
-      return false
-    }
+  if (!repoInfo?.owner || !repoInfo?.name) {
+    log('❌', 'Repository owner and name are required', 'red')
+    return false
+  }
 
-    const owner = repoInfo.owner
-    const repo = repoInfo.name
+  try {
+    const { owner, name: repo } = repoInfo
 
     if (commentType === 'review') {
       // Add reaction to review comment

--- a/src/github.js
+++ b/src/github.js
@@ -173,11 +173,6 @@ async function checkoutBranch (branchName, repoPath) {
  * - BASE_BRANCH: The base branch for PRs (defaults to 'main')
  */
 async function createPR (issue, branchName, repoInfo) {
-  if (!repoInfo?.owner || !repoInfo?.name) {
-    log('❌', 'Repository owner and name are required', 'red')
-    return null
-  }
-
   try {
     const { owner, name: repo } = repoInfo
     const baseBranch = process.env.BASE_BRANCH || 'main'
@@ -264,11 +259,6 @@ ${issue.description}`
  * @returns {Promise<Object|null>} The existing PR object if found, null otherwise
  */
 async function findExistingPR (issue, repoInfo) {
-  if (!repoInfo?.owner || !repoInfo?.name) {
-    log('❌', 'Repository owner and name are required', 'red')
-    return null
-  }
-
   try {
     const { owner, name: repo } = repoInfo
 
@@ -311,11 +301,6 @@ async function findExistingPR (issue, repoInfo) {
  */
 async function getPRComments (prNumber, repoInfo) {
   log('🔍', `Getting comments for PR #${prNumber}`, 'blue')
-
-  if (!repoInfo?.owner || !repoInfo?.name) {
-    log('❌', 'Repository owner and name are required', 'red')
-    return null
-  }
 
   try {
     const { owner, name: repo } = repoInfo
@@ -510,11 +495,6 @@ async function updateExistingPR (issue, repoInfo) {
 async function postReviewCommentReply (prNumber, inReplyToId, body, repoInfo) {
   log('💬', `Posting review comment reply to PR #${prNumber}`, 'blue')
 
-  if (!repoInfo?.owner || !repoInfo?.name) {
-    log('❌', 'Repository owner and name are required', 'red')
-    return null
-  }
-
   try {
     const { owner, name: repo } = repoInfo
 
@@ -559,11 +539,6 @@ async function postReviewCommentReply (prNumber, inReplyToId, body, repoInfo) {
  */
 async function postPRComment (prNumber, body, repoInfo, quotedComment = null) {
   log('💬', `Posting comment to PR #${prNumber}`, 'blue')
-
-  if (!repoInfo?.owner || !repoInfo?.name) {
-    log('❌', 'Repository owner and name are required', 'red')
-    return null
-  }
 
   try {
     const { owner, name: repo } = repoInfo
@@ -618,11 +593,6 @@ async function postPRComment (prNumber, body, repoInfo, quotedComment = null) {
  */
 async function addCommentReaction (commentId, commentType, reaction, repoInfo) {
   log('👁️', `Adding ${reaction} reaction to ${commentType} comment ${commentId}`, 'blue')
-
-  if (!repoInfo?.owner || !repoInfo?.name) {
-    log('❌', 'Repository owner and name are required', 'red')
-    return false
-  }
 
   try {
     const { owner, name: repo } = repoInfo

--- a/src/github.js
+++ b/src/github.js
@@ -170,16 +170,19 @@ async function checkoutBranch (branchName, repoPath) {
  *
  * @requires Environment variables:
  * - GITHUB_TOKEN: GitHub personal access token with repo scope
- * - GITHUB_OWNER: Default repository owner (optional if provided in repoInfo)
- * - GITHUB_REPO: Default repository name (optional if provided in repoInfo)
  * - BASE_BRANCH: The base branch for PRs (defaults to 'main')
  */
 async function createPR (issue, branchName, repoInfo) {
   try {
-    const owner = repoInfo?.owner || process.env.GITHUB_OWNER
-    const repo = repoInfo?.name || process.env.GITHUB_REPO
+    if (!repoInfo?.owner || !repoInfo?.name) {
+      log('❌', 'Repository owner and name are required', 'red')
+      return null
+    }
+
+    const owner = repoInfo.owner
+    const repo = repoInfo.name
     const baseBranch = process.env.BASE_BRANCH || 'main'
-    const repoPath = `./${repoInfo?.name || process.env.GITHUB_REPO}`
+    const repoPath = `./${repoInfo.name}`
 
     // Push the branch to remote before creating PR
     const git = simpleGit(repoPath)
@@ -263,8 +266,13 @@ ${issue.description}`
  */
 async function findExistingPR (issue, repoInfo) {
   try {
-    const owner = repoInfo?.owner || process.env.GITHUB_OWNER
-    const repo = repoInfo?.name || process.env.GITHUB_REPO
+    if (!repoInfo?.owner || !repoInfo?.name) {
+      log('❌', 'Repository owner and name are required', 'red')
+      return null
+    }
+
+    const owner = repoInfo.owner
+    const repo = repoInfo.name
 
     const { data: pulls } = await octokit.rest.pulls.list({
       owner,
@@ -307,13 +315,13 @@ async function getPRComments (prNumber, repoInfo) {
   log('🔍', `Getting comments for PR #${prNumber}`, 'blue')
 
   try {
-    const owner = repoInfo?.owner || process.env.GITHUB_OWNER
-    const repo = repoInfo?.name || process.env.GITHUB_REPO
-
-    if (!owner || !repo) {
+    if (!repoInfo?.owner || !repoInfo?.name) {
       log('❌', 'Repository owner and name are required', 'red')
       return null
     }
+
+    const owner = repoInfo.owner
+    const repo = repoInfo.name
 
     // Get line-specific review comments
     const { data: reviewComments } = await octokit.rest.pulls.listReviewComments({
@@ -506,13 +514,13 @@ async function postReviewCommentReply (prNumber, inReplyToId, body, repoInfo) {
   log('💬', `Posting review comment reply to PR #${prNumber}`, 'blue')
 
   try {
-    const owner = repoInfo?.owner || process.env.GITHUB_OWNER
-    const repo = repoInfo?.name || process.env.GITHUB_REPO
-
-    if (!owner || !repo) {
+    if (!repoInfo?.owner || !repoInfo?.name) {
       log('❌', 'Repository owner and name are required', 'red')
       return null
     }
+
+    const owner = repoInfo.owner
+    const repo = repoInfo.name
 
     // Post the reply to the review comment
     const { data: comment } = await octokit.rest.pulls.createReplyForReviewComment({
@@ -557,13 +565,13 @@ async function postPRComment (prNumber, body, repoInfo, quotedComment = null) {
   log('💬', `Posting comment to PR #${prNumber}`, 'blue')
 
   try {
-    const owner = repoInfo?.owner || process.env.GITHUB_OWNER
-    const repo = repoInfo?.name || process.env.GITHUB_REPO
-
-    if (!owner || !repo) {
+    if (!repoInfo?.owner || !repoInfo?.name) {
       log('❌', 'Repository owner and name are required', 'red')
       return null
     }
+
+    const owner = repoInfo.owner
+    const repo = repoInfo.name
 
     let finalBody = body
 
@@ -617,13 +625,13 @@ async function addCommentReaction (commentId, commentType, reaction, repoInfo) {
   log('👁️', `Adding ${reaction} reaction to ${commentType} comment ${commentId}`, 'blue')
 
   try {
-    const owner = repoInfo?.owner || process.env.GITHUB_OWNER
-    const repo = repoInfo?.name || process.env.GITHUB_REPO
-
-    if (!owner || !repo) {
+    if (!repoInfo?.owner || !repoInfo?.name) {
       log('❌', 'Repository owner and name are required', 'red')
       return false
     }
+
+    const owner = repoInfo.owner
+    const repo = repoInfo.name
 
     if (commentType === 'review') {
       // Add reaction to review comment

--- a/src/index.js
+++ b/src/index.js
@@ -67,7 +67,7 @@ async function processIssue (issue) {
   log('🔄', `Processing ${getIssueShortName(issue)}`, 'blue')
 
   // Check we have a known repository for the issue.
-  if (!issue.repository) {
+  if (!issue.repository?.owner || !issue.repository?.name) {
     log('⚠️', `No repository found for issue ${issue.identifier}. Skipping...`, 'yellow')
     return
   }


### PR DESCRIPTION
## Summary

Removed deprecated `GITHUB_OWNER` and `GITHUB_REPO` environment variables from the GitHub service. Repository information is now consistently sourced from the `REPOSITORY` variable parsing, with validation to ensure proper repository details are always provided. This change eliminates redundant environment variable dependencies and centralizes repository configuration management.

## Changes

- Removed fallback logic for `process.env.GITHUB_OWNER` and `process.env.GITHUB_REPO`
- Added validation to ensure `repoInfo` with owner and name is always provided
- Updated function parameters to require repository information explicitly
- Improved error handling for missing repository configuration