### PR TITLE
NOZ-86: Create Docker Image

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,67 @@
+# Docker Setup for Adam
+
+## Building the Docker Image
+
+Build the Docker image with:
+```bash
+docker build -t adam .
+```
+
+## Running Adam in Docker
+
+### Prerequisites
+
+1. **Claude Code Authentication**: Claude Code must be authenticated before running Adam in Docker. This cannot be done inside the Docker container itself.
+
+2. **Environment File**: Create a `.env` file with your configuration (see README.md for required variables).
+
+### Step-by-Step Setup
+
+1. **Prepare your environment file**:
+   ```bash
+   cp .env.example .env
+   # Edit .env with your actual API keys and configuration
+   ```
+
+2. **Run the Docker container**:
+   ```bash
+   docker run -it -v /path/to/your/.env:/app/config/.env adam
+   ```
+
+3. **Authenticate Claude Code**:
+   Once the container starts, you'll need to authenticate Claude Code:
+   ```bash
+   # In the container terminal that opens
+   claude
+   # Then type:
+   /login
+   # Follow the authentication prompts
+   ```
+
+4. **Start Adam**:
+   After authentication is complete, Adam will start automatically and begin processing Linear issues.
+
+### Alternative: Interactive Shell
+
+If you need to troubleshoot or work interactively:
+```bash
+docker run -it -v /path/to/your/.env:/app/config/.env --entrypoint /bin/bash adam
+```
+
+Then manually:
+1. Copy environment: `cp /app/config/.env /app/agents/adam/adam/.env`
+2. Authenticate Claude Code: `claude` then `/login`
+3. Start Adam: `npm run start`
+
+## Important Notes
+
+- **Authentication Requirement**: Claude Code authentication is required and must be done interactively after starting the container
+- **Volume Mount**: Your `.env` file must be mounted to `/app/config/.env` in the container
+- **Network Access**: The container needs internet access to communicate with Linear, GitHub, and Claude APIs
+- **Persistent Data**: Consider mounting a volume for git repositories if you want to persist cloned repos between container restarts
+
+## Troubleshooting
+
+- **Authentication Issues**: If Claude Code fails to authenticate, ensure you have a valid Anthropic account and API access
+- **Environment Variables**: Double-check that all required environment variables are set in your `.env` file
+- **Network Connectivity**: Ensure the container has access to external APIs (Linear, GitHub, Claude)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,87 @@
+# Use Ubuntu as base image
+FROM ubuntu:24.04
+
+# Set environment variables
+ENV DEBIAN_FRONTEND=noninteractive
+ENV NODE_VERSION=24
+
+# Install system dependencies and common developer tools
+RUN apt-get update && apt-get install -y \
+    curl \
+    wget \
+    git \
+    vim \
+    nano \
+    htop \
+    build-essential \
+    python3 \
+    python3-pip \
+    jq \
+    unzip \
+    zip \
+    tree \
+    less \
+    grep \
+    sed \
+    awk \
+    make \
+    gcc \
+    g++ \
+    ca-certificates \
+    gnupg \
+    lsb-release \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Node.js 24+ from NodeSource
+RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
+    && apt-get install -y nodejs
+
+# Verify Node.js installation
+RUN node --version && npm --version
+
+# Install Claude Code globally
+RUN npm install -g @anthropic-ai/claude-code
+
+# Set working directory
+WORKDIR /app
+
+# Clone the Adam repository
+RUN git clone https://github.com/nozcat/noz.git . \
+    && cd agents/adam/adam
+
+# Set working directory to Adam
+WORKDIR /app/agents/adam/adam
+
+# Install dependencies
+RUN npm install
+
+# Create a directory for environment configuration
+RUN mkdir -p /app/config
+
+# Copy package files and install dependencies
+COPY package*.json ./
+RUN npm install
+
+# Copy the rest of the application
+COPY . .
+
+# Create a script to handle environment variables and start the application
+RUN echo '#!/bin/bash\n\
+# Check if .env file exists in mounted volume\n\
+if [ -f /app/config/.env ]; then\n\
+    cp /app/config/.env /app/agents/adam/adam/.env\n\
+    echo "Environment file copied from mounted volume"\n\
+else\n\
+    echo "No .env file found in /app/config/. Please mount your .env file to /app/config/.env"\n\
+    echo "Example: docker run -v /path/to/your/.env:/app/config/.env adam"\n\
+    exit 1\n\
+fi\n\
+\n\
+# Start the application\n\
+npm run start' > /app/start.sh && chmod +x /app/start.sh
+
+# Expose any necessary ports (if Adam serves any web interface)
+# EXPOSE 3000
+
+# Set the default command
+CMD ["/app/start.sh"]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Adam runs in a continuous loop, checking for new issues and PR feedback every 30
 - **Linear API access** - API key with read access to your Linear workspace
 - **GitHub access** - Personal access token with repo permissions
 - **Claude Code** - Adam uses Claude Code to implement changes
+  - Install with: `npm install -g @anthropic-ai/claude-code`
+  - Requires authentication with your Anthropic account
 
 ### Setup
 
@@ -49,6 +51,43 @@ Adam runs in a continuous loop, checking for new issues and PR feedback every 30
    ```
 
 Adam will begin polling Linear for assigned issues and processing them automatically.
+
+## Docker Setup
+
+Adam can also be run in a Docker container for easier deployment and isolation.
+
+### Quick Start with Docker
+
+1. **Build the Docker image**:
+   ```bash
+   docker build -t adam .
+   ```
+
+2. **Run Adam in Docker**:
+   ```bash
+   docker run -it -v /path/to/your/.env:/app/config/.env adam
+   ```
+
+3. **Authenticate Claude Code** (required step):
+   When the container starts, you'll need to authenticate Claude Code:
+   ```bash
+   # In the container terminal
+   claude
+   # Then type: /login
+   # Follow the authentication prompts
+   ```
+
+After authentication, Adam will start automatically and begin processing issues.
+
+### Docker Features
+
+- **Ubuntu-based** with Node.js 24+ and common developer tools
+- **Claude Code pre-installed** globally
+- **Automatic repository cloning** from GitHub
+- **Environment variable handling** via mounted `.env` file
+- **Interactive authentication** support for Claude Code
+
+For detailed Docker setup instructions, see [DOCKER.md](DOCKER.md).
 
 ## Workflow for Interacting with Adam
 


### PR DESCRIPTION
Looking at the recent commit and issue context, I'll generate a concise PR description.

## Summary
Add Docker support for Adam with Ubuntu base image and Claude Code integration

## Changes
- **Docker Configuration**: Created Dockerfile with Ubuntu base, Node.js 24+, and common Linux developer tools
- **Claude Code Integration**: Added global installation of `@anthropic-ai/claude-code` npm package
- **Repository Setup**: Configured container to clone Adam repository from GitHub
- **Environment Handling**: Added support for .env file copying and environment variable configuration
- **Startup Process**: Configured container to run `npm run start` to launch Adam

## Documentation
- Added Docker usage instructions including authentication requirements
- Updated README with Claude Code installation and authentication steps
- Documented Docker build and run processes

## Notes
- Claude Code authentication must be performed interactively after container startup using `/login` command
- Container requires .env file or environment variables to be provided at runtime