### PR TITLE
NOZ-90: Make poll interval configurable

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,13 @@ const { pollLinear, getIssueShortName } = require('./linear')
 async function main () {
   log('🚀', 'Starting Adam - Linear to GitHub automation agent', 'green')
 
-  // Main worker loop. We poll for actions every 30 seconds.
+  // Get poll interval from environment variable, default to 30 seconds
+  const pollIntervalSeconds = parseInt(process.env.POLL_INTERVAL) || 30
+  const pollIntervalMs = pollIntervalSeconds * 1000
+
+  log('⏱️', `Poll interval set to ${pollIntervalSeconds} seconds`, 'blue')
+
+  // Main worker loop. We poll for actions at the configured interval.
   while (true) {
     const start = Date.now()
 
@@ -22,7 +28,7 @@ async function main () {
     }
 
     const elapsed = Date.now() - start
-    const remaining = 30000 - elapsed
+    const remaining = pollIntervalMs - elapsed
 
     if (remaining > 0) {
       await new Promise(resolve => setTimeout(resolve, remaining))


### PR DESCRIPTION
## Summary
Added configurable poll interval via `POLL_INTERVAL` environment variable with a 30-second default.

## Changes
- Parse `POLL_INTERVAL` environment variable as integer in startup configuration
- Display configured interval on application startup for visibility
- Update polling loop to use configurable interval instead of hardcoded 30-second value
- Maintain backward compatibility with 30-second default when environment variable is not set

## Testing
Verify the poll interval can be customized by setting the `POLL_INTERVAL` environment variable and confirm the application uses the specified interval for polling operations.