### PR TITLE
NOZ-92: Check for claude permissions each poll loop

### DIFF
--- a/src/claude.js
+++ b/src/claude.js
@@ -4,6 +4,31 @@ const { marked } = require('marked')
 const { log, DEBUG } = require('./util')
 
 /**
+ * Checks if Claude Code has proper permissions by running a simple command
+ * @returns {Promise<boolean>} True if Claude has permissions, false otherwise
+ */
+async function checkClaudePermissions () {
+  return new Promise((resolve) => {
+    const args = ['--print', "don't do anything"]
+    const options = { stdio: ['ignore', 'pipe', 'pipe'] }
+    const claude = spawn('claude', args, options)
+
+    claude.on('close', (code) => {
+      if (code === 0) {
+        resolve(true)
+      } else {
+        resolve(false)
+      }
+    })
+
+    claude.on('error', (error) => {
+      log('❌', `Failed to check Claude permissions: ${error.message}`, 'red')
+      resolve(false)
+    })
+  })
+}
+
+/**
  * Executes Claude Code with the given prompt and returns the result
  * @param {string} prompt - The prompt to send to Claude Code
  * @param {string} dir - The directory to run Claude Code in
@@ -313,4 +338,4 @@ function limitLinesWithMore (content, maxLines = 10) {
   return topLines.join('\n') + '\n' + chalk.dim(moreIndicator) + '\n' + bottomLines.join('\n')
 }
 
-module.exports = { callClaude }
+module.exports = { callClaude, checkClaudePermissions }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 require('dotenv').config()
 
-const { callClaude } = require('./claude')
+const { callClaude, checkClaudePermissions } = require('./claude')
 const { log } = require('./util')
 const { ensureRepositoryExists, checkoutBranch, createPR, findExistingPR, updateExistingPR, getPRComments, postPRComment, postReviewCommentReply, addCommentReaction, pushBranch } = require('./github')
 const { pollLinear, getIssueShortName } = require('./linear')
@@ -40,6 +40,13 @@ async function main () {
  * Perform one iteration of actions in the main loop.
  */
 async function performActions () {
+  // Check Claude permissions before doing anything else
+  const hasPermissions = await checkClaudePermissions()
+  if (!hasPermissions) {
+    log('❌', 'Invalid API key · Please run /login', 'red')
+    return
+  }
+
   const issues = await pollLinear()
 
   printIssues(issues)


### PR DESCRIPTION
## Summary

Adds Claude API authentication check to prevent unnecessary processing when not logged in. The system now validates Claude permissions at the start of each poll loop iteration using a simple `claude --print` command and skips processing if authentication fails.

## Changes

- **Authentication Guard**: Added `checkClaudePermissions()` function that validates API key by running `claude --print "don't do anything"` and checking exit code
- **Poll Loop Protection**: Modified main poll loop to check permissions before processing any Linear issues
- **Error Handling**: Gracefully handles authentication failures with clear error messaging and early return

## Impact

- Prevents wasted API calls and processing when Claude is not authenticated
- Provides immediate feedback when authentication is required
- Maintains existing functionality while adding defensive authentication checks