### PR TITLE
NOZ-93: Document and include POLL_INTERVAL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,7 @@ BASE_BRANCH=main
 
 # Whether to print debug logs
 DEBUG=false
+
+# Poll interval in seconds for checking Linear issues and GitHub PR feedback
+# Default: 30 seconds
+POLL_INTERVAL=30

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Adam is a developer AI agent that automates the software development workflow by
 - **Responding to feedback** - Processes PR comments and feedback, implements requested changes, and responds to conversation threads
 - **Managing Git workflow** - Handles branch creation, commits, and push operations
 
-Adam runs in a continuous loop, checking for new issues and PR feedback every 30 seconds, making it a fully automated development assistant.
+Adam runs in a continuous loop, checking for new issues and PR feedback at configurable intervals (default: 30 seconds), making it a fully automated development assistant.
 
 ## Starting Adam
 
@@ -43,6 +43,7 @@ Adam runs in a continuous loop, checking for new issues and PR feedback every 30
    # Optional
    BASE_BRANCH=main
    DEBUG=false
+   POLL_INTERVAL=30
    ```
 
 3. **Start Adam**


### PR DESCRIPTION
## Summary

Documents the configurable POLL_INTERVAL environment variable for controlling how frequently Adam checks for new Linear issues and GitHub PR feedback. This was previously a hardcoded 30-second interval and is now configurable via environment variables.

## Changes

- Added POLL_INTERVAL to `.env.example` with default value of 30 seconds and documentation
- Updated README to mention configurable polling intervals instead of hardcoded "30 seconds"
- Added POLL_INTERVAL to the environment variable list in setup instructions