### PR TITLE
NOZ-95: Bug: If cloning the repo fails, we should not do anything after that

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -86,10 +86,9 @@ async function processIssue (issue) {
   }
 
   // Clone the repository if it doesn't exist.
-  try {
-    await ensureRepositoryExists(issue.repository)
-  } catch (error) {
-    log('❌', `Failed to ensure repository exists for issue ${issue.identifier}: ${error.message}`, 'red')
+  const repoExists = await ensureRepositoryExists(issue.repository)
+  if (!repoExists) {
+    log('❌', `Failed to ensure repository exists for issue ${issue.identifier}`, 'red')
     return
   }
 


### PR DESCRIPTION
## Summary

Fixes repository cloning error handling by properly checking the return value of `ensureRepositoryExists`. Previously, the function's return value was ignored, causing the application to continue processing even when repository cloning failed. Now it correctly stops processing when repository setup fails.

## Test plan

- [ ] Verify that processing stops when repository cloning fails
- [ ] Confirm error logging works correctly
- [ ] Test normal flow continues when repository exists or is successfully cloned