### PR TITLE
NOZ-87: Improve the generated PR descriptions

### DIFF
--- a/src/github.js
+++ b/src/github.js
@@ -226,8 +226,8 @@ async function generatePRDescription (issue, baseBranch, repoPath) {
 
     const commitList = commits.all.map(commit => `- ${commit.hash}`).join('\n')
     const prompt = `
-Generate and return a concise PR description based on these recent commits.
-Focus on what was changed and why. Return only the description without any preamble or explanation.
+You are writing a PR description. Write a concise description based on these recent commits.
+Focus on what was changed and why. Do not include any introductory text, preambles, or explanations - start directly with the description content.
 
 Recent commits:
 ${commitList}


### PR DESCRIPTION
Looking at the commit and issue context, here's a concise PR description:

## Summary

Fixed PR description generation to eliminate unwanted introductory text that was appearing before the actual description content.

## Changes

- Updated the prompt in `generatePRDescription` to ensure clean, direct PR descriptions without meta-commentary or preamble text

## Impact

PR descriptions will now start directly with the summary content instead of including explanatory text about the generation process.