### PR TITLE
NOZ-94: Bug: If push fails after responding to PR feedback, try pull and merge

### DIFF
--- a/src/github.js
+++ b/src/github.js
@@ -696,7 +696,7 @@ async function pushBranchAndMergeIfNecessary (branchName, repoInfo, issue) {
       // Fetch latest changes
       await git.fetch()
 
-      // Pull latest changes from remote branch
+      // Pull latest changes from remote branch (this will merge into current branch)
       try {
         await git.pull('origin', branchName)
         log('📥', `Pulled latest changes for branch: ${branchName}`, 'blue')

--- a/src/github.js
+++ b/src/github.js
@@ -720,15 +720,6 @@ async function pushBranchAndMergeIfNecessary (branchName, repoInfo, issue) {
       // Fetch latest changes
       await git.fetch()
 
-      // Pull latest changes from remote branch (this will merge into current branch)
-      try {
-        await git.pull('origin', branchName)
-        log('📥', `Pulled latest changes for branch: ${branchName}`, 'blue')
-      } catch (pullError) {
-        // If pull fails, the remote branch might not exist, which is okay
-        log('ℹ️', `Could not pull from remote branch ${branchName}: ${pullError.message}`, 'blue')
-      }
-
       // Check if we need to merge with base branch
       const behindCommits = await git.log([`HEAD..origin/${baseBranch}`])
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ require('dotenv').config()
 
 const { callClaude, checkClaudePermissions } = require('./claude')
 const { log, getRepoPath } = require('./util')
-const { ensureRepositoryExists, checkoutBranch, createPR, findExistingPR, updateExistingPR, getPRComments, postPRComment, postReviewCommentReply, addCommentReaction, pushBranch } = require('./github')
+const { ensureRepositoryExists, checkoutBranch, createPR, findExistingPR, updateExistingPR, getPRComments, postPRComment, postReviewCommentReply, addCommentReaction, pushBranchAndMergeIfNecessary } = require('./github')
 const { pollLinear, getIssueShortName } = require('./linear')
 
 /**
@@ -189,8 +189,8 @@ async function processExistingPR (existingPR, issue) {
             if (comment) {
               log('💬', `Successfully posted Claude response for thread ${i + 1} as ${lastComment.type} ${lastComment.type === 'review' ? 'reply' : 'quoted comment'} to GitHub PR`, 'green')
 
-              // Push the branch to remote after making changes
-              const pushSuccess = await pushBranch(issue.branchName, issue.repository)
+              // Push the branch to remote after making changes, merging if necessary
+              const pushSuccess = await pushBranchAndMergeIfNecessary(issue.branchName, issue.repository, issue)
               if (pushSuccess) {
                 log('📤', `Successfully pushed changes to remote branch after thread ${i + 1}`, 'green')
               } else {


### PR DESCRIPTION
## Summary
Fixes NOZ-94 by implementing intelligent push with automatic merge handling when push fails after responding to PR feedback.

## Changes
- Created `pushBranchAndMergeIfNecessary` helper function that replaces direct `pushBranch` calls
- Function attempts push first, then automatically pulls and merges base branch if push fails
- Reuses existing Claude-based intelligent merge logic to preserve original PR intent during conflicts
- Updated `processExistingPR` to use the new helper function
- Handles edge cases where local branch diverges from remote after PR feedback responses

## Test plan
- [ ] Test push success path (no merge needed)
- [ ] Test push failure with successful automatic merge
- [ ] Test push failure with merge conflicts requiring Claude intervention
- [ ] Verify original PR intent is preserved during merge operations