### PR TITLE
NOZ-102: Bug: Adam implemented the same linear issue twice due to race condition

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ require('dotenv').config()
 const { callClaude, checkClaudePermissions } = require('./claude')
 const { log, getRepoPath } = require('./util')
 const { ensureRepositoryExists, checkoutBranch, createPR, findExistingPR, updateExistingPR, getPRComments, postPRComment, postReviewCommentReply, addCommentReaction, pushBranch } = require('./github')
-const { pollLinear, getIssueShortName } = require('./linear')
+const { pollLinear, checkIssueStatus, getIssueShortName } = require('./linear')
 
 /**
  * Main entry point.
@@ -102,7 +102,31 @@ async function processIssue (issue) {
   // Check if the PR already exists.
   const existingPR = await findExistingPR(issue, issue.repository)
   if (existingPR) {
+    // Check if this is a merged PR (race condition detected)
+    if (existingPR.merged) {
+      log('🛑', `Skipping issue ${issue.identifier} - PR was already merged`, 'yellow')
+      return
+    }
     await processExistingPR(existingPR, issue)
+    return
+  }
+
+  // Before calling Claude, double-check that the issue is still in Todo or In Progress
+  log('🔍', `Double-checking issue status before implementing ${issue.identifier}...`, 'blue')
+  const currentIssue = await checkIssueStatus(issue.id)
+  if (!currentIssue) {
+    log('❌', `Failed to check current status for issue ${issue.identifier}`, 'red')
+    return
+  }
+
+  const currentState = await currentIssue.state
+  if (currentState.name === 'Done') {
+    log('🛑', `Issue ${issue.identifier} has been marked as Done - skipping to avoid race condition`, 'yellow')
+    return
+  }
+
+  if (!['Todo', 'In Progress'].includes(currentState.name)) {
+    log('🛑', `Issue ${issue.identifier} is no longer in Todo or In Progress state (current: ${currentState.name}) - skipping`, 'yellow')
     return
   }
 
@@ -112,6 +136,17 @@ async function processIssue (issue) {
   if (!claudeSuccess) {
     log('❌', `Claude Code failed for issue: ${issue.identifier}`, 'red')
     return
+  }
+
+  // Before creating PR, do one final check that the issue hasn't been marked as Done
+  log('🔍', `Final check before creating PR for ${issue.identifier}...`, 'blue')
+  const finalIssue = await checkIssueStatus(issue.id)
+  if (finalIssue) {
+    const finalState = await finalIssue.state
+    if (finalState.name === 'Done') {
+      log('🛑', `Issue ${issue.identifier} was marked as Done during implementation - not creating PR to avoid race condition`, 'yellow')
+      return
+    }
   }
 
   // Create a PR for the issue.

--- a/src/linear.js
+++ b/src/linear.js
@@ -27,7 +27,7 @@ async function pollLinear () {
 }
 
 /**
- * Get all assigned issues.
+ * Get all assigned issues that are Todo or In Progress.
  *
  * @returns {Promise<Array>} A list of issues.
  */
@@ -38,7 +38,7 @@ async function getAssignedIssues () {
     const issues = await linearClient.issues({
       filter: {
         assignee: { id: { eq: user.id } },
-        state: { name: { nin: ['Backlog', 'Done', 'Canceled', 'Duplicate'] } }
+        state: { name: { in: ['Todo', 'In Progress'] } }
       }
     })
 
@@ -86,6 +86,22 @@ function extractRepository (content) {
 }
 
 /**
+ * Re-fetch a single issue to check its current status
+ *
+ * @param {string} issueId - The Linear issue ID to check
+ * @returns {Promise<Object|null>} The issue object or null if not found/error
+ */
+async function checkIssueStatus (issueId) {
+  try {
+    const issue = await linearClient.issue(issueId)
+    return issue
+  } catch (error) {
+    log('❌', `Error checking issue status for ${issueId}: ${error.message}`, 'red')
+    return null
+  }
+}
+
+/**
  * Get the short name of an issue for display.
  *
  * @param {Object} issue - The issue to get the short name from.
@@ -98,5 +114,6 @@ function getIssueShortName (issue) {
 
 module.exports = {
   pollLinear,
+  checkIssueStatus,
   getIssueShortName
 }


### PR DESCRIPTION
Fixes race condition preventing Adam from implementing the same Linear issue multiple times. 

**Changes:**
- Add status validation before pushing initial code - only process issues in "Todo" or "In Progress" states
- Check for squash-merged PRs when determining if issue already has implementation
- Prevent duplicate work when issue transitions from "In Review" to "Done" between PR merge and Linear status update

**Root cause:** After squash-merging a PR but before Linear issue status updated to "Done", Adam would see the issue still marked "In Review" with no open PR and begin duplicate implementation.