### PR TITLE
NOZ-106: Bug: If no project is assigned, log a nice error

### DIFF
--- a/src/linear.js
+++ b/src/linear.js
@@ -58,6 +58,10 @@ async function getAssignedIssues () {
 async function getRepositoryFromIssue (issue) {
   try {
     const project = await issue.project
+    if (!project) {
+      log('⚠️', `No project assigned to issue ${issue.identifier}`, 'yellow')
+      return null
+    }
     const repository = extractRepository(project.content)
     return repository
   } catch (error) {


### PR DESCRIPTION
Fixed a bug where Linear issues without an assigned project would throw an unclear error when trying to access the project's content property. Added a proper null check that now logs a user-friendly warning message instead of crashing with "Cannot read properties of undefined (reading 'content')".