### PR TITLE
NOZ-113: Bug: We're not checking for PR feedback one an issue is marked in review on Linear

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -111,7 +111,7 @@ async function processIssue (issue) {
     return
   }
 
-  // Before calling Claude, double-check that the issue is still in Todo or In Progress
+  // Before calling Claude, double-check that the issue is still in Todo, In Progress, or In Review
   log('🔍', `Double-checking issue status before implementing ${issue.identifier}...`, 'blue')
   const currentIssue = await checkIssueStatus(issue.id)
   if (!currentIssue) {
@@ -125,8 +125,8 @@ async function processIssue (issue) {
     return
   }
 
-  if (!['Todo', 'In Progress'].includes(currentState.name)) {
-    log('🛑', `Issue ${issue.identifier} is no longer in Todo or In Progress state (current: ${currentState.name}) - skipping`, 'yellow')
+  if (!['Todo', 'In Progress', 'In Review'].includes(currentState.name)) {
+    log('🛑', `Issue ${issue.identifier} is no longer in Todo, In Progress, or In Review state (current: ${currentState.name}) - skipping`, 'yellow')
     return
   }
 

--- a/src/linear.js
+++ b/src/linear.js
@@ -62,7 +62,7 @@ async function isIssueBlocked (issue) {
 }
 
 /**
- * Get all assigned issues that are Todo or In Progress.
+ * Get all assigned issues that are Todo, In Progress, or in Review.
  *
  * @returns {Promise<Array>} A list of issues.
  */
@@ -73,7 +73,7 @@ async function getAssignedIssues () {
     const issues = await linearClient.issues({
       filter: {
         assignee: { id: { eq: user.id } },
-        state: { name: { in: ['Todo', 'In Progress'] } }
+        state: { name: { in: ['Todo', 'In Progress', 'In Review'] } }
       }
     })
 


### PR DESCRIPTION
Fixed issue where Linear issues marked as 'In Review' were being filtered out when checking for PR feedback. Previously, only 'Todo' and 'In Progress' issues were retrieved, causing issues in review state to be skipped entirely. Updated the Linear query filter and status validation logic to include 'In Review' status.