### PR TITLE
NOZ-119: Bug: Failed to create label

### DIFF
--- a/src/linear.js
+++ b/src/linear.js
@@ -477,7 +477,7 @@ async function findOrCreateLabel (labelName) {
       description: `Temporary label indicating this issue is being processed by ${agentId}`
     })
 
-    return newLabel.issueLabel.id
+    return (await newLabel.issueLabel).id
   } catch (error) {
     log('❌', `Error finding or creating label ${labelName}: ${error.message}`, 'red')
     return null


### PR DESCRIPTION
Looking at the commit and issue context, I'll write a concise PR description:

## Summary
Fixed async handling in label creation to prevent race conditions that were causing "Failed to lock issue" errors.

## Changes
- Updated label creation code to properly await the `issueLabel` promise before accessing its `id` property
- Changed `return newLabel.issueLabel.id` to `return (await newLabel.issueLabel).id`

## Impact
Resolves race condition errors where the system would skip processing issues due to improper async handling during label creation.