### PR TITLE
NOZ-121: Document that 4 agents works best with a Claude MAX Subscription

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Both Adam and Eve modes can be run in Docker containers for easier deployment an
 
 The easiest way to run Adam with Docker is using Docker Compose. By default, it will start 4 Adam agents (adam1-adam4) and one Eve agent:
 
+**Note on Claude MAX Subscription:** Running 4 Adam agents concurrently works best with a Claude MAX subscription. Each agent requires access to Claude Code, and the MAX subscription provides the necessary rate limits and concurrent request capacity to support multiple agents working in parallel. With a standard Claude subscription, you may experience rate limiting or reduced performance when running all 4 agents simultaneously.
+
 1. **Prepare your environment file**:
    ```bash
    cp .env.example .env

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Both Adam and Eve modes can be run in Docker containers for easier deployment an
 
 The easiest way to run Adam with Docker is using Docker Compose. By default, it will start 4 Adam agents (adam1-adam4) and one Eve agent:
 
-**Note on Claude MAX Subscription:** Running 4 Adam agents concurrently works best with a Claude MAX subscription. Each agent requires access to Claude Code, and the MAX subscription provides the necessary rate limits and concurrent request capacity to support multiple agents working in parallel. With a standard Claude subscription, you may experience rate limiting or reduced performance when running all 4 agents simultaneously.
+**Note on Claude MAX Subscription:** Running 4 Adam agents concurrently works best with a Claude MAX subscription. Each agent requires access to Claude Code, and the MAX subscription provides the necessary request limits to support multiple agents working in parallel. With a standard Claude subscription, you might run out of requests pretty quickly if more than one Adam agent stays busy for a while.
 
 1. **Prepare your environment file**:
    ```bash


### PR DESCRIPTION
## Summary

Updates the Docker Compose documentation to clarify that running 4 concurrent Adam agents requires a Claude MAX subscription for optimal performance.

## Changes

- Added a note in the Docker Compose section of README.md explaining that 4 Adam agents work best with Claude MAX subscription due to rate limits and concurrent request requirements
- Clarifies that standard Claude subscriptions may experience rate limiting or reduced performance when running multiple agents simultaneously

This documentation helps users understand the subscription requirements before attempting to run the default multi-agent Docker Compose configuration.