### PR TITLE
NOZ-125: Use labels to specify repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,12 +214,12 @@ Then manually:
 
 ### 1. Repository Configuration
 
-Each Linear project must specify the target repository in its content using the format:
+Issues in Linear must have a label that specifies the target repository using the format:
 ```
-REPOSITORY=owner/repo-name
+repo:owner/repo-name
 ```
 
-This tells Adam which GitHub repository to work with for issues in that project.
+For example, a label `repo:acme/backend` tells Adam to work with the `backend` repository owned by `acme`. This label-based approach allows for easier configuration without modifying project content.
 
 ### 2. Issue Assignment
 


### PR DESCRIPTION
This PR updates the repository specification mechanism to use issue labels instead of parsing repository information from the issue description. The new format uses `repo:<owner>/<name>` labels to clearly identify which repository an issue belongs to.

**Changes:**
- Modified issue parsing logic to extract repository information from labels rather than issue content
- Implemented support for `repo:<owner>/<name>` label format
- Updated issue processing to prioritize label-based repository identification

This provides a cleaner and more explicit way to associate issues with repositories, improving clarity and reducing parsing errors.