### PR TITLE
NOZ-123: Bug: Two agents took the same issue again

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,10 +238,12 @@ For example, a label `repo:acme/backend` tells Adam to work with the `backend` r
 
 Adam will:
 - Detect the assigned issue
+- Lock the issue by adding an `agent:` label to prevent multiple agents from working on the same issue
 - Clone or update the target repository
 - Create a branch for the issue (based on issue identifier)
 - Use Claude Code to implement the changes
 - Create a pull request with the implementation
+- Unlock the issue by removing the agent label when done
 
 ### 4. PR Feedback and Iteration
 

--- a/src/linear.js
+++ b/src/linear.js
@@ -403,10 +403,11 @@ async function lockIssue (issue) {
     const updatedIssue = await linearClient.issue(issue.id)
     const updatedLabels = await updatedIssue.labels()
     const updatedLabelNames = updatedLabels?.nodes ? updatedLabels.nodes.map(label => label.name) : []
+    log('🔒', `Issue ${issue.identifier} has labels: ${updatedLabelNames}`, 'blue')
 
     // Check for other agent labels (excluding our own)
     const otherAgentLabels = updatedLabelNames.filter(name =>
-      name.startsWith('agent-') && name !== labelName
+      name.startsWith('agent:') && name !== labelName
     )
 
     if (otherAgentLabels.length > 0) {


### PR DESCRIPTION
Fixed issue where multiple agents could claim the same GitHub issue by correcting the agent label prefix check from `agent-` to `agent:`. The bug occurred because agents were looking for labels with the wrong prefix when determining if another agent had already claimed an issue.

Added logging to the `lockIssue` function to display the current labels when an issue is being locked, which helps with debugging agent assignment conflicts.

Updated README to document that agents are assigned a label in the format `agent:<agent-name>` when they claim an issue.