### PR TITLE
NOZ-129: Add the API server to docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,11 @@ The easiest way to run Adam with Docker is using Docker Compose. By default, it 
    docker-compose up -d
    ```
    This will start:
+   - 1 API server (adam-api-server) that provides centralized API management
    - 4 Adam agents (adam1, adam2, adam3, adam4) running continuously
    - 1 Eve agent (eve) which exits immediately (still under development)
+   
+   All agents are configured to use the centralized API server running on the Docker network.
 
 3. **Authenticate Claude Code for each Adam agent**:
    Connect to each running Adam container to authenticate:

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ The easiest way to run Adam with Docker is using Docker Compose. By default, it 
    docker-compose up -d
    ```
    This will start:
-   - 1 API server (adam-api-server) that provides centralized API management
+   - 1 API server (api-server) that provides centralized API management
    - 4 Adam agents (adam1, adam2, adam3, adam4) running continuously
    - 1 Eve agent (eve) which exits immediately (still under development)
    

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,6 @@ services:
       - GITHUB_TOKEN=${GITHUB_TOKEN}
       - API_PORT=8880
       - DEBUG=${DEBUG:-false}
-    ports:
-      - "8880:8880"
     networks:
       - adam-network
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,19 @@
 services:
+  api-server:
+    build: .
+    container_name: adam-api-server
+    restart: unless-stopped
+    environment:
+      - MODE=api
+      - LINEAR_API_KEY=${LINEAR_API_KEY}
+      - GITHUB_TOKEN=${GITHUB_TOKEN}
+      - API_PORT=8880
+      - DEBUG=${DEBUG:-false}
+    ports:
+      - "8880:8880"
+    networks:
+      - adam-network
+
   adam1:
     build: .
     container_name: adam1-agent
@@ -15,6 +30,7 @@ services:
       - POLL_INTERVAL=${POLL_INTERVAL:-30}
       - REPOS_DIR=${REPOS_DIR:-./repos}
       - REPOS=${REPOS}
+      - API_SERVER=api-server:8880
     volumes:
       # Mount a volume for persistent git repositories
       - adam1_repos:/app/repos
@@ -22,6 +38,8 @@ services:
     tty: true
     networks:
       - adam-network
+    depends_on:
+      - api-server
 
   adam2:
     build: .
@@ -39,6 +57,7 @@ services:
       - POLL_INTERVAL=${POLL_INTERVAL:-30}
       - REPOS_DIR=${REPOS_DIR:-./repos}
       - REPOS=${REPOS}
+      - API_SERVER=api-server:8880
     volumes:
       # Mount a volume for persistent git repositories
       - adam2_repos:/app/repos
@@ -46,6 +65,8 @@ services:
     tty: true
     networks:
       - adam-network
+    depends_on:
+      - api-server
 
   adam3:
     build: .
@@ -63,6 +84,7 @@ services:
       - POLL_INTERVAL=${POLL_INTERVAL:-30}
       - REPOS_DIR=${REPOS_DIR:-./repos}
       - REPOS=${REPOS}
+      - API_SERVER=api-server:8880
     volumes:
       # Mount a volume for persistent git repositories
       - adam3_repos:/app/repos
@@ -70,6 +92,8 @@ services:
     tty: true
     networks:
       - adam-network
+    depends_on:
+      - api-server
 
   adam4:
     build: .
@@ -87,6 +111,7 @@ services:
       - POLL_INTERVAL=${POLL_INTERVAL:-30}
       - REPOS_DIR=${REPOS_DIR:-./repos}
       - REPOS=${REPOS}
+      - API_SERVER=api-server:8880
     volumes:
       # Mount a volume for persistent git repositories
       - adam4_repos:/app/repos
@@ -94,6 +119,8 @@ services:
     tty: true
     networks:
       - adam-network
+    depends_on:
+      - api-server
 
   eve:
     build: .
@@ -111,6 +138,7 @@ services:
       - POLL_INTERVAL=${POLL_INTERVAL:-30}
       - REPOS_DIR=${REPOS_DIR:-./repos}
       - REPOS=${REPOS}
+      - API_SERVER=api-server:8880
     volumes:
       # Mount a volume for persistent git repositories
       - eve_repos:/app/repos
@@ -118,6 +146,8 @@ services:
     tty: true
     networks:
       - adam-network
+    depends_on:
+      - api-server
 
 volumes:
   adam1_repos:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   api-server:
     build: .
-    container_name: adam-api-server
+    container_name: api-server
     restart: unless-stopped
     environment:
       - MODE=api


### PR DESCRIPTION
This PR adds a centralized API server to the docker-compose setup, enabling agents to communicate through a shared API instead of operating independently.

The API server runs in API mode on port 8880 and provides Linear and GitHub integration capabilities. All agent containers (adam1-4 and eve) are configured to use this API server via the API_SERVER environment variable, with proper dependency management to ensure the API server starts before agents.

This architecture allows agents to coordinate their actions and share state through the centralized API, improving collaboration and reducing duplicate work when handling issues.